### PR TITLE
Small fixes

### DIFF
--- a/lib/plz/arguments.rb
+++ b/lib/plz/arguments.rb
@@ -7,12 +7,12 @@ module Plz
 
     # @return [String, nil] Given action name
     def action_name
-      ARGV[0]
+      @argv[0]
     end
 
     # @return [String, nil] Given target name
     def target_name
-      ARGV[1]
+      @argv[1]
     end
 
     # @return [Hash] Params parsed from given arguments & STDIN
@@ -23,7 +23,7 @@ module Plz
 
     # @return [Hash] Headers parsed from given arguments
     def headers
-      ARGV[2..-1].inject({}) do |result, section|
+      @argv[2..-1].inject({}) do |result, section|
         case
         when /(?<key>.+):(?<value>[^=]+)/ =~ section
           result.merge(key => value)
@@ -56,7 +56,7 @@ module Plz
 
     # @return [Hash] Params extracted from ARGV
     def params_from_argv
-      @params_from_argv ||= ARGV[2..-1].inject({}) do |result, section|
+      @params_from_argv ||= @argv[2..-1].inject({}) do |result, section|
         case
         when /(?<key>.+):=(?<value>.+)/ =~ section
           begin

--- a/lib/plz/command_builder.rb
+++ b/lib/plz/command_builder.rb
@@ -45,8 +45,8 @@ module Plz
       when !has_link?
         Commands::LinkNotFound.new(
           pathname: schema_file_pathname,
-          action_name: nil,
-          target_name: nil
+          action_name: action_name,
+          target_name: target_name,
         )
       when has_invalid_json_input?
         Commands::InvalidJsonFromStdin.new


### PR DESCRIPTION
Practical fix: Use an instance variable instead of ARGV for argument parsing (looks like this was half-done already)

Cosmetic fix: Don't omit info in the error message